### PR TITLE
Request ext

### DIFF
--- a/Sources/FluentExt/Request+Filter.swift
+++ b/Sources/FluentExt/Request+Filter.swift
@@ -8,7 +8,7 @@
 
 import Vapor
 
-public extension Request { //where Result: Model, Result.Database == Database {
+public extension Request {
     /// Build filter criteria over a keypath using criteria configured in a request query params.
     ///
     /// - Parameters:

--- a/Sources/FluentExt/Request+Sort.swift
+++ b/Sources/FluentExt/Request+Sort.swift
@@ -15,10 +15,9 @@ public extension Request {
     ///   - keyPath: the model keypath.
     ///   - queryParam: the sorting parameter name in the query params url.
     ///   - parameter: the parameter name in sorting config.
-    ///   - direction: Default direction to apply if no value is found in url query params.
     /// - Returns: QuerySort criteria
     /// - Throws: FluentError
-    public func sort<M, T>(_ keyPath: KeyPath<M, T>, at queryParam: String, as parameter: String, default direction: M.Database.QuerySortDirection? = nil) throws -> M.Database.QuerySort? where M: Model {
+    public func sort<M, T>(_ keyPath: KeyPath<M, T>, at queryParam: String, as parameter: String) throws -> M.Database.QuerySort? where M: Model {
         if let sort = self.query[String.self, at: queryParam] {
             let sortOpts = sort.components(separatedBy: ",")
 
@@ -43,11 +42,35 @@ public extension Request {
             }
         }
 
-        if let direction = direction {
-            return M.Database.querySort(M.Database.queryField(.keyPath(keyPath)), direction)
+        return nil
+    }
+
+    /// Build sort criteria over a keypath using criteria configured in a request query params.
+    ///
+    /// - Parameters:
+    ///   - keyPath: the model keypath.
+    ///   - queryParam: the sorting parameter name in the query params url.
+    ///   - parameter: the parameter name in sorting config.
+    ///   - direction: Default direction to apply if no value is found in url query params.
+    /// - Returns: QuerySort criteria
+    /// - Throws: FluentError
+    public func sort<M, T>(_ keyPath: KeyPath<M, T>, at queryParam: String, as parameter: String, default direction: M.Database.QuerySortDirection) throws -> M.Database.QuerySort where M: Model {
+        if let sort = try self.sort(keyPath, at: queryParam, as: parameter) {
+            return sort
         }
 
-        return nil
+        return M.Database.querySort(M.Database.queryField(.keyPath(keyPath)), direction)
+    }
+
+    /// Build sort criteria over a keypath using criteria configured in a request query params.
+    ///
+    /// - Parameters:
+    ///   - keyPath: the model keypath.
+    ///   - parameter: the parameter name in sorting config.
+    /// - Returns: QuerySort criteria
+    /// - Throws: FluentError
+    public func sort<M, T>(_ keyPath: KeyPath<M, T>, as parameter: String) throws -> M.Database.QuerySort? where M: Model {
+        return try self.sort(keyPath, at: "sort", as: parameter)
     }
 
     /// Build sort criteria over a keypath using criteria configured in a request query params.
@@ -58,7 +81,7 @@ public extension Request {
     ///   - direction: Default direction to apply if no value is found in url query params.
     /// - Returns: QuerySort criteria
     /// - Throws: FluentError
-    public func sort<M, T>(_ keyPath: KeyPath<M, T>, as parameter: String, default direction: M.Database.QuerySortDirection? = nil) throws -> M.Database.QuerySort? where M: Model {
+    public func sort<M, T>(_ keyPath: KeyPath<M, T>, as parameter: String, default direction: M.Database.QuerySortDirection) throws -> M.Database.QuerySort where M: Model {
         return try self.sort(keyPath, at: "sort", as: parameter, default: direction)
     }
 }

--- a/Sources/FluentExt/Request+Sort.swift
+++ b/Sources/FluentExt/Request+Sort.swift
@@ -1,0 +1,64 @@
+//
+//  Request+Sort.swift
+//  FluentExt
+//
+//  Created by Gustavo Perdomo on 08/09/18.
+//  Copyright © 2018 Vapor Community. All rights reserved.
+//
+
+import Vapor
+
+public extension Request {
+    /// Build sort criteria over a keypath using criteria configured in a request query params.
+    ///
+    /// - Parameters:
+    ///   - keyPath: the model keypath.
+    ///   - queryParam: the sorting parameter name in the query params url.
+    ///   - parameter: the parameter name in sorting config.
+    ///   - direction: Default direction to apply if no value is found in url query params.
+    /// - Returns: QuerySort criteria
+    /// - Throws: FluentError
+    public func sort<M, T>(_ keyPath: KeyPath<M, T>, at queryParam: String, as parameter: String, default direction: M.Database.QuerySortDirection? = nil) throws -> M.Database.QuerySort? where M: Model {
+        if let sort = self.query[String.self, at: queryParam] {
+            let sortOpts = sort.components(separatedBy: ",")
+
+            for option in sortOpts {
+                let splited = option.components(separatedBy: ":")
+
+                let field = splited[0]
+
+                if field != parameter {
+                    continue
+                }
+
+                let direction = splited.count == 1 ? "asc" : splited[1]
+
+                guard ["asc", "desc"].contains(direction) else {
+                    throw FluentError(identifier: "invalidSortConfiguration", reason: "Invalid sort config for '\(option)'")
+                }
+
+                let dir = direction == "asc" ? M.Database.querySortDirectionAscending: M.Database.querySortDirectionDescending
+
+                return M.Database.querySort(M.Database.queryField(.keyPath(keyPath)), dir)
+            }
+        }
+
+        if let direction = direction {
+            return M.Database.querySort(M.Database.queryField(.keyPath(keyPath)), direction)
+        }
+
+        return nil
+    }
+
+    /// Build sort criteria over a keypath using criteria configured in a request query params.
+    ///
+    /// - Parameters:
+    ///   - keyPath: the model keypath.
+    ///   - parameter: the parameter name in sorting config.
+    ///   - direction: Default direction to apply if no value is found in url query params.
+    /// - Returns: QuerySort criteria
+    /// - Throws: FluentError
+    public func sort<M, T>(_ keyPath: KeyPath<M, T>, as parameter: String, default direction: M.Database.QuerySortDirection? = nil) throws -> M.Database.QuerySort? where M: Model {
+        return try self.sort(keyPath, at: "sort", as: parameter, default: direction)
+    }
+}


### PR DESCRIPTION
- New Request extensions to build FilterOperator and QuerySort from query params (Usefull if you use a Repository system):
  - `filter(keyPath:, at parameter:)` to build FilterOperator based in query params
  - `sort(keyPath:, at queryParam:, as parameter:)` to build QuerySort based in query params
  - `sort(keyPath:, at queryParam:, as parameter:, default direction:)` to build QuerySort based in query params
  - `sort(keyPath:, as parameter:)` to build QuerySort based in query params
  - `sort(keyPath:, as parameter:, default direction:)` to build QuerySort based in query params