### PR TITLE
Allow single quotes around value

### DIFF
--- a/Sources/ServiceExt/Environment+DotEnv.swift
+++ b/Sources/ServiceExt/Environment+DotEnv.swift
@@ -52,6 +52,14 @@ public extension Environment {
                 value.remove(at: value.index(before: value.endIndex))
                 value = value.replacingOccurrences(of: "\\\"", with: "\"")
             }
+            
+            // remove surrounding single quotes from value & convert remove escape character before any embedded quotes
+            if value[value.startIndex] == "'" && value[value.index(before: value.endIndex)] == "'" {
+                value.remove(at: value.startIndex)
+                value.remove(at: value.index(before: value.endIndex))
+                value = value.replacingOccurrences(of: "'", with: "'")
+            }
+            
             setenv(key, value, 1)
         }
     }


### PR DESCRIPTION
This PR adds support for Single quote around .env values. This is quite normal this is allowed.

Before:
FOO='Bar' // 'Bar'

After
FOO='Bar' // Bar