### PR TITLE
Remove warnings from Swift 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Packages
 /*.xcodeproj
 Package.resolved
+DerivedData/

--- a/Sources/AsyncExt/Future+Bool.swift
+++ b/Sources/AsyncExt/Future+Bool.swift
@@ -20,7 +20,7 @@ public extension Future where T == Bool {
     /// - Parameter error: The error to be thrown.
     /// - Returns: The result of the comparison wrapped in a Future.
     /// - Throws: Throws the passed error in the opposite case.
-    public func `true`(or error: Error) throws -> Future<Bool> {
+    func `true`(or error: Error) throws -> Future<Bool> {
         return map(to: Bool.self) { boolean in
             if !boolean {
                 throw error
@@ -38,7 +38,7 @@ public extension Future where T == Bool {
     /// - Parameter error: The error to be thrown.
     /// - Returns: The result of the comparison wrapped in a Future.
     /// - Throws: Throws the passed error in the opposite case.
-    public func `false`(or error: Error) throws -> Future<Bool> {
+    func `false`(or error: Error) throws -> Future<Bool> {
         return map(to: Bool.self) { boolean in
             if boolean {
                 throw error

--- a/Sources/AsyncExt/Future+Comparable.swift
+++ b/Sources/AsyncExt/Future+Comparable.swift
@@ -19,7 +19,7 @@ public extension Future where T: Comparable {
     ///
     /// - Parameter value: The value to compare.
     /// - Returns: The result of the comparison wrapped in a Future.
-    public func greater(than value: T) -> Future<Bool> {
+    func greater(than value: T) -> Future<Bool> {
         return map(to: Bool.self) { current in
             current > value
         }
@@ -36,7 +36,7 @@ public extension Future where T: Comparable {
     ///   - error: The error to be thrown.
     /// - Returns: The result of the comparison wrapped in a Future.
     /// - Throws: Throws the passed error if the current value is not greater than the passed value.
-    public func greater(than value: T, or error: Error) throws -> Future<Bool> {
+    func greater(than value: T, or error: Error) throws -> Future<Bool> {
         return try greater(than: value).true(or: error)
     }
 
@@ -48,7 +48,7 @@ public extension Future where T: Comparable {
     ///
     /// - Parameter value: The value to compare.
     /// - Returns: The result of the comparison wrapped in a Future.
-    public func greaterOrEqual(to value: T) -> Future<Bool> {
+    func greaterOrEqual(to value: T) -> Future<Bool> {
         return map(to: Bool.self) { current in
             current >= value
         }
@@ -65,7 +65,7 @@ public extension Future where T: Comparable {
     ///   - error: The error to be thrown.
     /// - Returns: The result of the comparison wrapped in a Future.
     /// - Throws: Throws the passed error if the current value is not greater or equal to the passed value.
-    public func greaterOrEqual(to value: T, or error: Error) throws -> Future<Bool> {
+    func greaterOrEqual(to value: T, or error: Error) throws -> Future<Bool> {
         return try greaterOrEqual(to: value).true(or: error)
     }
 
@@ -77,7 +77,7 @@ public extension Future where T: Comparable {
     ///
     /// - Parameter value: The value to compare.
     /// - Returns: The result of the comparison wrapped in a Future.
-    public func less(than value: T) -> Future<Bool> {
+    func less(than value: T) -> Future<Bool> {
         return map(to: Bool.self) { current in
             current < value
         }
@@ -94,7 +94,7 @@ public extension Future where T: Comparable {
     ///   - error: The error to be thrown.
     /// - Returns: The result of the comparison wrapped in a Future.
     /// - Throws: Throws the passed error if the current value is not less than the passed value.
-    public func less(than value: T, or error: Error) throws -> Future<Bool> {
+    func less(than value: T, or error: Error) throws -> Future<Bool> {
         return try less(than: value).true(or: error)
     }
 
@@ -106,7 +106,7 @@ public extension Future where T: Comparable {
     ///
     /// - Parameter value: The value to compare.
     /// - Returns: The result of the comparison wrapped in a Future.
-    public func lessOrEqual(to value: T) -> Future<Bool> {
+    func lessOrEqual(to value: T) -> Future<Bool> {
         return map(to: Bool.self) { current in
             current <= value
         }
@@ -123,7 +123,7 @@ public extension Future where T: Comparable {
     ///   - error: The error to be thrown.
     /// - Returns: The result of the comparison wrapped in a Future.
     /// - Throws: Throws the passed error if the current value is not less or equal to the passed value.
-    public func lessOrEqual(to value: T, or error: Error) throws -> Future<Bool> {
+    func lessOrEqual(to value: T, or error: Error) throws -> Future<Bool> {
         return try lessOrEqual(to: value).true(or: error)
     }
 }

--- a/Sources/AsyncExt/Future+Equatable.swift
+++ b/Sources/AsyncExt/Future+Equatable.swift
@@ -19,7 +19,7 @@ public extension Future where T: Equatable {
     ///
     /// - Parameter value: The value to compare.
     /// - Returns: The result of the comparison wrapped in a Future.
-    public func equal(to value: T) -> Future<Bool> {
+    func equal(to value: T) -> Future<Bool> {
         return map(to: Bool.self) { current in
             current == value
         }
@@ -36,7 +36,7 @@ public extension Future where T: Equatable {
     ///   - error: The error to be thrown.
     /// - Returns: The result of the comparison wrapped in a Future.
     /// - Throws: Throws the passed error if values are not equals.
-    public func equal(to value: T, or error: Error) throws -> Future<Bool> {
+    func equal(to value: T, or error: Error) throws -> Future<Bool> {
         return try map(to: Bool.self) { current in
             current == value
         }.true(or: error)
@@ -50,7 +50,7 @@ public extension Future where T: Equatable {
     ///
     /// - Parameter value: The value to compare.
     /// - Returns: The result of the comparison wrapped in a Future.
-    public func notEqual(to value: T) -> Future<Bool> {
+    func notEqual(to value: T) -> Future<Bool> {
         return map(to: Bool.self) { current in
             current != value
         }
@@ -67,7 +67,7 @@ public extension Future where T: Equatable {
     ///   - error: The error to be thrown.
     /// - Returns: The result of the comparison wrapped in a Future.
     /// - Throws: Throws the passed error if values are not equals.
-    public func notEqual(to value: T, or error: Error) throws -> Future<Bool> {
+    func notEqual(to value: T, or error: Error) throws -> Future<Bool> {
         return try map(to: Bool.self) { current in
             current != value
         }.true(or: error)

--- a/Sources/AsyncExt/Future+Optional.swift
+++ b/Sources/AsyncExt/Future+Optional.swift
@@ -10,7 +10,7 @@ import Async
 import Core
 
 public extension Future where Expectation: OptionalType {
-    public func `nil`(or error: @autoclosure @escaping () -> Error) -> Future<Expectation.WrappedType?> {
+    func `nil`(or error: @autoclosure @escaping () -> Error) -> Future<Expectation.WrappedType?> {
         return map { optional in
             if let _ = optional.wrapped {
                 throw error()
@@ -20,7 +20,7 @@ public extension Future where Expectation: OptionalType {
         }
     }
 
-    public func `nil`() -> Future<Bool> {
+    func `nil`() -> Future<Bool> {
         return map { optional in
             optional.wrapped == nil
         }

--- a/Sources/FluentExt/Extensions/QueryBuilder+Filter.swift
+++ b/Sources/FluentExt/Extensions/QueryBuilder+Filter.swift
@@ -24,7 +24,7 @@ public extension QueryBuilder where Result: Model, Result.Database == Database {
     ///   - req: the request.
     /// - Returns: Self
     /// - Throws: FluentError
-    public func filter<T>(_ keyPath: KeyPath<Result, T>, at parameter: String, on req: Request) throws -> Self where T: Codable {
+    func filter<T>(_ keyPath: KeyPath<Result, T>, at parameter: String, on req: Request) throws -> Self where T: Codable {
         let decoder = try req.make(ContentCoders.self).requireDataDecoder(for: .urlEncodedForm)
 
         guard let config = req.query[String.self, at: parameter] else {
@@ -79,7 +79,7 @@ public extension QueryBuilder where Result: Model, Result.Database == Database, 
     ///   - req: the request.
     /// - Returns: Self
     /// - Throws: FluentError
-    public func filter(_ keyPath: KeyPath<Result, String>, at parameter: String, on req: Request) throws -> Self {
+    func filter(_ keyPath: KeyPath<Result, String>, at parameter: String, on req: Request) throws -> Self {
         let decoder = try req.make(ContentCoders.self).requireDataDecoder(for: .urlEncodedForm)
 
         guard let config = req.query[String.self, at: parameter] else {
@@ -145,7 +145,7 @@ public extension QueryBuilder where Result: Model, Result.Database == Database, 
     ///   - req: the request.
     /// - Returns: Self
     /// - Throws: FluentError
-    public func filter(_ keyPath: KeyPath<Result, String?>, at parameter: String, on req: Request) throws -> Self {
+    func filter(_ keyPath: KeyPath<Result, String?>, at parameter: String, on req: Request) throws -> Self {
         let decoder = try req.make(ContentCoders.self).requireDataDecoder(for: .urlEncodedForm)
 
         guard let config = req.query[String.self, at: parameter] else {

--- a/Sources/FluentExt/Extensions/QueryBuilder+Sort.swift
+++ b/Sources/FluentExt/Extensions/QueryBuilder+Sort.swift
@@ -20,7 +20,7 @@ public extension QueryBuilder where Result: Model, Result.Database == Database {
     ///   - req: the request.
     /// - Returns: Self
     /// - Throws: FluentError
-    public func sort<T>(_ keyPath: KeyPath<Result, T>, at queryParam: String, as parameter: String, default direction: Database.QuerySortDirection? = nil, on req: Request) throws -> Self {
+    func sort<T>(_ keyPath: KeyPath<Result, T>, at queryParam: String, as parameter: String, default direction: Database.QuerySortDirection? = nil, on req: Request) throws -> Self {
         if let sort = req.query[String.self, at: queryParam] {
             let sortOpts = sort.components(separatedBy: ",")
 
@@ -59,7 +59,7 @@ public extension QueryBuilder where Result: Model, Result.Database == Database {
     ///   - req: the request.
     /// - Returns: Self
     /// - Throws: FluentError
-    public func sort<T>(_ keyPath: KeyPath<Result, T>, as parameter: String, default direction: Database.QuerySortDirection? = nil, on req: Request) throws -> Self {
+    func sort<T>(_ keyPath: KeyPath<Result, T>, as parameter: String, default direction: Database.QuerySortDirection? = nil, on req: Request) throws -> Self {
         return try sort(keyPath, at: "sort", as: parameter, default: direction, on: req)
     }
 
@@ -67,7 +67,7 @@ public extension QueryBuilder where Result: Model, Result.Database == Database {
     ///
     /// - Parameter sorts: Some `QuerySort`s to be applied.
     /// - Returns: Self
-    public func sort(by sorts: [Database.QuerySort]? = nil) -> Self {
+    func sort(by sorts: [Database.QuerySort]? = nil) -> Self {
         sorts?.forEach { sort in
             Database.querySortApply(sort, to: &query)
         }

--- a/Sources/FluentExt/Extensions/Request+Filter.swift
+++ b/Sources/FluentExt/Extensions/Request+Filter.swift
@@ -16,7 +16,7 @@ public extension Request {
     ///   - parameter: the parameter name in filter config from request url params.
     /// - Returns: FilterOperator
     /// - Throws: FluentError
-    public func filter<Result, T>(_ keyPath: KeyPath<Result, T>, at parameter: String) throws -> FilterOperator<Result.Database, Result>? where T: Codable, Result: Model {
+    func filter<Result, T>(_ keyPath: KeyPath<Result, T>, at parameter: String) throws -> FilterOperator<Result.Database, Result>? where T: Codable, Result: Model {
         let decoder = try make(ContentCoders.self).requireDataDecoder(for: .urlEncodedForm)
 
         guard let config = self.query[String.self, at: parameter] else {
@@ -68,7 +68,7 @@ public extension Request {
     ///   - parameter: the parameter name in filter config from request url params.
     /// - Returns: FilterOperator
     /// - Throws: FluentError
-    public func filter<Result>(_ keyPath: KeyPath<Result, String>, at parameter: String) throws -> FilterOperator<Result.Database, Result>? where Result: Model, Result.Database.QueryFilterMethod: SQLBinaryOperator {
+    func filter<Result>(_ keyPath: KeyPath<Result, String>, at parameter: String) throws -> FilterOperator<Result.Database, Result>? where Result: Model, Result.Database.QueryFilterMethod: SQLBinaryOperator {
         let decoder = try make(ContentCoders.self).requireDataDecoder(for: .urlEncodedForm)
 
         guard let config = self.query[String.self, at: parameter] else {
@@ -132,7 +132,7 @@ public extension Request {
     ///   - parameter: the parameter name in filter config from request url params.
     /// - Returns: FilterOperator
     /// - Throws: FluentError
-    public func filter<Result>(_ keyPath: KeyPath<Result, String?>, at parameter: String) throws -> FilterOperator<Result.Database, Result>? where Result: Model, Result.Database.QueryFilterMethod: SQLBinaryOperator {
+    func filter<Result>(_ keyPath: KeyPath<Result, String?>, at parameter: String) throws -> FilterOperator<Result.Database, Result>? where Result: Model, Result.Database.QueryFilterMethod: SQLBinaryOperator {
         let decoder = try make(ContentCoders.self).requireDataDecoder(for: .urlEncodedForm)
 
         guard let config = self.query[String.self, at: parameter] else {

--- a/Sources/FluentExt/Extensions/Request+Sort.swift
+++ b/Sources/FluentExt/Extensions/Request+Sort.swift
@@ -17,7 +17,7 @@ public extension Request {
     ///   - parameter: the parameter name in sorting config.
     /// - Returns: QuerySort criteria
     /// - Throws: FluentError
-    public func sort<M, T>(_ keyPath: KeyPath<M, T>, at queryParam: String, as parameter: String) throws -> M.Database.QuerySort? where M: Model {
+    func sort<M, T>(_ keyPath: KeyPath<M, T>, at queryParam: String, as parameter: String) throws -> M.Database.QuerySort? where M: Model {
         if let sort = self.query[String.self, at: queryParam] {
             let sortOpts = sort.components(separatedBy: ",")
 
@@ -54,7 +54,7 @@ public extension Request {
     ///   - direction: Default direction to apply if no value is found in url query params.
     /// - Returns: QuerySort criteria
     /// - Throws: FluentError
-    public func sort<M, T>(_ keyPath: KeyPath<M, T>, at queryParam: String, as parameter: String, default direction: M.Database.QuerySortDirection) throws -> M.Database.QuerySort where M: Model {
+    func sort<M, T>(_ keyPath: KeyPath<M, T>, at queryParam: String, as parameter: String, default direction: M.Database.QuerySortDirection) throws -> M.Database.QuerySort where M: Model {
         if let sort = try self.sort(keyPath, at: queryParam, as: parameter) {
             return sort
         }
@@ -69,7 +69,7 @@ public extension Request {
     ///   - parameter: the parameter name in sorting config.
     /// - Returns: QuerySort criteria
     /// - Throws: FluentError
-    public func sort<M, T>(_ keyPath: KeyPath<M, T>, as parameter: String) throws -> M.Database.QuerySort? where M: Model {
+    func sort<M, T>(_ keyPath: KeyPath<M, T>, as parameter: String) throws -> M.Database.QuerySort? where M: Model {
         return try sort(keyPath, at: "sort", as: parameter)
     }
 
@@ -81,7 +81,7 @@ public extension Request {
     ///   - direction: Default direction to apply if no value is found in url query params.
     /// - Returns: QuerySort criteria
     /// - Throws: FluentError
-    public func sort<M, T>(_ keyPath: KeyPath<M, T>, as parameter: String, default direction: M.Database.QuerySortDirection) throws -> M.Database.QuerySort where M: Model {
+    func sort<M, T>(_ keyPath: KeyPath<M, T>, as parameter: String, default direction: M.Database.QuerySortDirection) throws -> M.Database.QuerySort where M: Model {
         return try sort(keyPath, at: "sort", as: parameter, default: direction)
     }
 }

--- a/Sources/ServiceExt/Environment+DotEnv.swift
+++ b/Sources/ServiceExt/Environment+DotEnv.swift
@@ -21,7 +21,7 @@ public extension Environment {
     /// Loads environment variables from .env files.
     ///
     /// - Parameter filename: name of your env file.
-    public static func dotenv(filename: String = ".env") {
+    static func dotenv(filename: String = ".env") {
         guard let path = getAbsolutePath(for: filename),
             let contents = try? String(contentsOfFile: path, encoding: .utf8) else {
             return

--- a/Sources/ServiceExt/Environment+Getters.swift
+++ b/Sources/ServiceExt/Environment+Getters.swift
@@ -21,7 +21,7 @@ public extension Environment {
     ///
     /// - Parameter key: the environment variable name.
     /// - Returns: the environment variable value if exists.
-    public static func get(_ key: String) -> Int? {
+    static func get(_ key: String) -> Int? {
         if let value: String = self.get(key), let parsed = Int(value) {
             return parsed
         }
@@ -33,7 +33,7 @@ public extension Environment {
     ///
     /// - Parameter key: the environment variable name.
     /// - Returns: the environment variable value if exists.
-    public static func get(_ key: String) -> Bool? {
+    static func get(_ key: String) -> Bool? {
         if let value: String = self.get(key), let parsed = value.lowercased().bool {
             return parsed
         }
@@ -47,7 +47,7 @@ public extension Environment {
     ///   - key: the environment variable name.
     ///   - fallback: the default value.
     /// - Returns: the environment variable value if exists, otherwise the `fallback` value.
-    public static func get(_ key: String, _ fallback: String) -> String {
+    static func get(_ key: String, _ fallback: String) -> String {
         return get(key) ?? fallback
     }
 
@@ -57,7 +57,7 @@ public extension Environment {
     ///   - key: the environment variable name.
     ///   - fallback: the default value.
     /// - Returns: the environment variable value if exists, otherwise the `fallback` value.
-    public static func get(_ key: String, _ fallback: Int) -> Int {
+    static func get(_ key: String, _ fallback: Int) -> Int {
         guard let value: Int = self.get(key) else {
             return fallback
         }
@@ -71,7 +71,7 @@ public extension Environment {
     ///   - key: the environment variable name.
     ///   - fallback: the default value.
     /// - Returns: the environment variable value if exists, otherwise the `fallback` value.
-    public static func get(_ key: String, _ fallback: Bool) -> Bool {
+    static func get(_ key: String, _ fallback: Bool) -> Bool {
         guard let value: Bool = self.get(key) else {
             return fallback
         }

--- a/Sources/VaporExt/Encodable+Response.swift
+++ b/Sources/VaporExt/Encodable+Response.swift
@@ -15,7 +15,7 @@ public extension Future where T: Encodable {
     ///   - contentType: The MediaType to encode the data
     /// - Returns: A Future<Response> with the encodable data
     /// - Throws: Errors errors during encoding
-    public func toResponse(on req: Request, as status: HTTPStatus, contentType: MediaType = .json) throws -> Future<Response> {
+    func toResponse(on req: Request, as status: HTTPStatus, contentType: MediaType = .json) throws -> Future<Response> {
         return map(to: Response.self) { encodable in
             let response = req.response()
             try response.content.encode(encodable, as: contentType)


### PR DESCRIPTION
Removes redundant public modifiers that cause warnings in Swift 5